### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joethorley


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning @joethorley as code owner.

Closes #12.